### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mcp-memory-libsql
 
+[![smithery badge](https://smithery.ai/badge/mcp-memory-libsql)](https://smithery.ai/server/mcp-memory-libsql)
+
 A high-performance, persistent memory system for the Model Context Protocol (MCP) powered by libSQL. This server provides vector search capabilities and efficient knowledge storage using libSQL as the backing store.
 
 ## Features


### PR DESCRIPTION
This PR makes the following change to the README:

1. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-memory-libsql

Let me know if any tweaks have to be made!